### PR TITLE
Fix repeated Uart Tx packet in Rx Uart channel

### DIFF
--- a/src/libmodbus/modbus-rtu.cpp
+++ b/src/libmodbus/modbus-rtu.cpp
@@ -327,9 +327,11 @@ static ssize_t _modbus_rtu_send(modbus_t *ctx, const uint8_t *req, int req_lengt
 
     ssize_t size;
 
+    RS485.noReceive();
     RS485.beginTransmission();
     size = RS485.write(req, req_length);
     RS485.endTransmission();
+    RS485.receive();
 
     return size;
 #else


### PR DESCRIPTION
This fix allow to solve the problem of the repeated Tx packet in uart rx channel https://github.com/bcmi-labs/ArduinoModbus/issues/2, it was tested with the example ModbusRTUTemperatureSensor, it show that the master unit receive only one time te packet, and that the packet is not replicated on the Uart rx channel.