### PR TITLE
De-hardcoded `RS485Class` object to be used by modbus.

### DIFF
--- a/src/ModbusRTUClient.cpp
+++ b/src/ModbusRTUClient.cpp
@@ -34,9 +34,9 @@ ModbusRTUClientClass::~ModbusRTUClientClass()
 {
 }
 
-int ModbusRTUClientClass::begin(unsigned long baudrate, uint16_t config)
+int ModbusRTUClientClass::begin(unsigned long baudrate, uint16_t config, RS485Class& rs485)
 {
-  modbus_t* mb = modbus_new_rtu(baudrate, config);
+  modbus_t* mb = modbus_new_rtu(baudrate, config, &rs485);
 
   if (!ModbusClient::begin(mb, 0x00)) {
     return 0;
@@ -45,6 +45,11 @@ int ModbusRTUClientClass::begin(unsigned long baudrate, uint16_t config)
   modbus_set_response_timeout(mb, 1, 0);
 
   return 1;
+}
+
+int ModbusRTUClientClass::begin(unsigned long baudrate, RS485Class& rs485)
+{
+  return begin(baudrate, SERIAL_8N1, rs485);
 }
 
 ModbusRTUClientClass ModbusRTUClient;

--- a/src/ModbusRTUClient.h
+++ b/src/ModbusRTUClient.h
@@ -22,6 +22,8 @@
 
 #include "ModbusClient.h"
 
+#include <ArduinoRS485.h>
+
 class ModbusRTUClientClass : public ModbusClient {
 public:
   ModbusRTUClientClass();
@@ -35,7 +37,8 @@ public:
    *
    * Return 1 on success, 0 on failure
    */
-  int begin(unsigned long baudrate, uint16_t config = SERIAL_8N1);
+  int begin(unsigned long baudrate, uint16_t config = SERIAL_8N1, RS485Class& rs485 = RS485);
+  int begin(unsigned long baudrate, RS485Class& rs485);
 };
 
 extern ModbusRTUClientClass ModbusRTUClient;

--- a/src/ModbusRTUServer.cpp
+++ b/src/ModbusRTUServer.cpp
@@ -34,9 +34,9 @@ ModbusRTUServerClass::~ModbusRTUServerClass()
 {
 }
 
-int ModbusRTUServerClass::begin(int id, unsigned long baudrate, uint16_t config)
+int ModbusRTUServerClass::begin(int id, unsigned long baudrate, uint16_t config, RS485Class& rs485)
 {
-  modbus_t* mb = modbus_new_rtu(baudrate, config);
+  modbus_t* mb = modbus_new_rtu(baudrate, config, &rs485);
 
   if (!ModbusServer::begin(mb, id)) {
     return 0;
@@ -45,6 +45,11 @@ int ModbusRTUServerClass::begin(int id, unsigned long baudrate, uint16_t config)
   modbus_connect(mb);
 
   return 1;
+}
+
+int ModbusRTUServerClass::begin(int id, unsigned long baudrate, RS485Class& rs485)
+{
+  return begin(id, baudrate, SERIAL_8N1, RS485);
 }
 
 void ModbusRTUServerClass::poll()

--- a/src/ModbusRTUServer.h
+++ b/src/ModbusRTUServer.h
@@ -22,6 +22,8 @@
 
 #include "ModbusServer.h"
 
+#include <ArduinoRS485.h>
+
 class ModbusRTUServerClass : public ModbusServer {
 public:
   ModbusRTUServerClass();
@@ -36,7 +38,8 @@ public:
    *
    * Return 1 on success, 0 on failure
    */
-  int begin(int id, unsigned long baudrate, uint16_t config = SERIAL_8N1);
+  int begin(int id, unsigned long baudrate, uint16_t config = SERIAL_8N1, RS485Class& rs485 = RS485);
+  int begin(int id, unsigned long baudrate, RS485Class& rs485);
 
   /**
    * Poll interface for requests

--- a/src/libmodbus/modbus-rtu-private.h
+++ b/src/libmodbus/modbus-rtu-private.h
@@ -17,7 +17,7 @@
 #if defined(_WIN32)
 #include <windows.h>
 #elif defined(ARDUINO)
-// nothing extra needed
+#include <ArduinoRS485.h>
 #else
 #include <termios.h>
 #endif
@@ -49,6 +49,7 @@ typedef struct _modbus_rtu {
 #if defined(ARDUINO)
     unsigned long baud;
     uint16_t config;
+    RS485Class* rs485;
 #else
     /* Device: "/dev/ttyS0", "/dev/ttyUSB0" or "/dev/tty.USA19*" on Mac OS X. */
     char *device;

--- a/src/libmodbus/modbus-rtu.h
+++ b/src/libmodbus/modbus-rtu.h
@@ -8,7 +8,12 @@
 #ifndef MODBUS_RTU_H
 #define MODBUS_RTU_H
 
+#ifdef ARDUINO
+class RS485Class;
+#endif
+
 #include "modbus.h"
+
 
 MODBUS_BEGIN_DECLS
 
@@ -18,7 +23,7 @@ MODBUS_BEGIN_DECLS
 #define MODBUS_RTU_MAX_ADU_LENGTH  256
 
 #ifdef ARDUINO
-MODBUS_API modbus_t* modbus_new_rtu(unsigned long baud, uint16_t config);
+MODBUS_API modbus_t* modbus_new_rtu(unsigned long baud, uint16_t config, RS485Class* rs485);
 #else
 MODBUS_API modbus_t* modbus_new_rtu(const char *device, int baud, char parity,
                                     int data_bit, int stop_bit);


### PR DESCRIPTION
This proposed change makes it possible to use an `RS485Class` object other than the default `RS485` with the contained `libmodbus`. This is useful with boards with multiple serial ports or when the user wants to specify different DE/RE pins.