### PR TITLE
Adds Ethernet Examples

### DIFF
--- a/examples/TCP/EthernetModbusClientToggle/EthernetModbusClientToggle.ino
+++ b/examples/TCP/EthernetModbusClientToggle/EthernetModbusClientToggle.ino
@@ -1,0 +1,87 @@
+/*
+  Ethernet Modbus TCP Client Toggle
+
+  This sketch toggles the coil of a Modbus TCP server connected
+  on and off every second.
+
+  Circuit:
+   - Any Arduino MKR Board
+   - MKR ETH Shield
+
+  created 16 July 2018
+  by Sandeep Mistry
+*/
+
+#include <SPI.h>
+#include <Ethernet.h>
+
+#include <ArduinoRS485.h> // ArduinoModbus depends on the ArduinoRS485 library
+#include <ArduinoModbus.h>
+
+// Enter a MAC address for your controller below.
+// Newer Ethernet shields have a MAC address printed on a sticker on the shield
+// The IP address will be dependent on your local network:
+byte mac[] = {
+  0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED
+};
+IPAddress ip(192, 168, 1, 177);
+
+EthernetClient ethClient;
+ModbusTCPClient modbusTCPClient(ethClient);
+
+IPAddress server(192, 168, 1, 10); // update with the IP Address of your Modbus server
+
+void setup() {
+  //Initialize serial and wait for port to open:
+  Serial.begin(9600);
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for native USB port only
+  }
+
+  // start the Ethernet connection and the server:
+  Ethernet.begin(mac, ip);
+
+  // Check for Ethernet hardware present
+  if (Ethernet.hardwareStatus() == EthernetNoHardware) {
+    Serial.println("Ethernet shield was not found.  Sorry, can't run without hardware. :(");
+    while (true) {
+      delay(1); // do nothing, no point running without Ethernet hardware
+    }
+  }
+  if (Ethernet.linkStatus() == LinkOFF) {
+    Serial.println("Ethernet cable is not connected.");
+  }
+}
+
+void loop() {
+  if (!modbusTCPClient.connected()) {
+    // client not connected, start the Modbus TCP client
+    Serial.println("Attempting to connect to Modbus TCP server");
+    
+    if (!modbusTCPClient.begin(server, 502)) {
+      Serial.println("Modbus TCP Client failed to connect!");
+    } else {
+      Serial.println("Modbus TCP Client connected");
+    }
+  } else {
+    // client connected
+
+    // write the value of 0x01, to the coil at address 0x00
+    if (!modbusTCPClient.coilWrite(0x00, 0x01)) {
+      Serial.print("Failed to write coil! ");
+      Serial.println(modbusTCPClient.lastError());
+    }
+
+    // wait for 1 second
+    delay(1000);
+
+    // write the value of 0x00, to the coil at address 0x00
+    if (!modbusTCPClient.coilWrite(0x00, 0x00)) {
+      Serial.print("Failed to write coil! ");
+      Serial.println(modbusTCPClient.lastError());
+    }
+
+    // wait for 1 second
+    delay(1000);
+  }
+}

--- a/examples/TCP/EthernetModbusServerLED/EthernetModbusServerLED.ino
+++ b/examples/TCP/EthernetModbusServerLED/EthernetModbusServerLED.ino
@@ -1,0 +1,116 @@
+/*
+  Ethernet Modbus TCP Server LED
+
+  This sketch creates a Modbus TCP Server with a simulated coil.
+  The value of the simulated coil is set on the LED
+
+  Circuit:
+   - Any Arduino MKR Board
+   - MKR ETH Shield
+
+  created 16 July 2018
+  by Sandeep Mistry
+*/
+
+#include <SPI.h>
+#include <Ethernet.h>
+
+#include <ArduinoRS485.h> // ArduinoModbus depends on the ArduinoRS485 library
+#include <ArduinoModbus.h>
+
+// Enter a MAC address for your controller below.
+// Newer Ethernet shields have a MAC address printed on a sticker on the shield
+// The IP address will be dependent on your local network:
+byte mac[] = {
+  0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED
+};
+IPAddress ip(192, 168, 1, 177);
+
+EthernetServer ethServer(502);
+
+ModbusTCPServer modbusTCPServer;
+
+const int ledPin = LED_BUILTIN;
+
+void setup() {
+  // You can use Ethernet.init(pin) to configure the CS pin
+  //Ethernet.init(10);  // Most Arduino shields
+  //Ethernet.init(5);   // MKR ETH shield
+  //Ethernet.init(0);   // Teensy 2.0
+  //Ethernet.init(20);  // Teensy++ 2.0
+  //Ethernet.init(15);  // ESP8266 with Adafruit Featherwing Ethernet
+  //Ethernet.init(33);  // ESP32 with Adafruit Featherwing Ethernet
+
+  // Open serial communications and wait for port to open:
+  Serial.begin(9600);
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for native USB port only
+  }
+  Serial.println("Ethernet Modbus TCP Example");
+
+  // start the Ethernet connection and the server:
+  Ethernet.begin(mac, ip);
+
+  // Check for Ethernet hardware present
+  if (Ethernet.hardwareStatus() == EthernetNoHardware) {
+    Serial.println("Ethernet shield was not found.  Sorry, can't run without hardware. :(");
+    while (true) {
+      delay(1); // do nothing, no point running without Ethernet hardware
+    }
+  }
+  if (Ethernet.linkStatus() == LinkOFF) {
+    Serial.println("Ethernet cable is not connected.");
+  }
+
+  // start the server
+  ethServer.begin();
+  
+  // start the Modbus TCP server
+  if (!modbusTCPServer.begin()) {
+    Serial.println("Failed to start Modbus TCP Server!");
+    while (1);
+  }
+
+  // configure the LED
+  pinMode(ledPin, OUTPUT);
+  digitalWrite(ledPin, LOW);
+
+  // configure a single coil at address 0x00
+  modbusTCPServer.configureCoils(0x00, 1);
+}
+
+void loop() {
+  // listen for incoming clients
+  EthernetClient client = ethServer.available();
+  
+  if (client) {
+    // a new client connected
+    Serial.println("new client");
+
+    // let the Modbus TCP accept the connection 
+    modbusTCPServer.accept(client);
+
+    while (client.connected()) {
+      // poll for Modbus TCP requests, while client connected
+      modbusTCPServer.poll();
+
+      // update the LED
+      updateLED();
+    }
+
+    Serial.println("client disconnected");
+  }
+}
+
+void updateLED() {
+  // read the current value of the coil
+  int coilValue = modbusTCPServer.coilRead(0x00);
+
+  if (coilValue) {
+    // coil value set, turn LED on
+    digitalWrite(ledPin, HIGH);
+  } else {
+    // coild value clear, turn LED off
+    digitalWrite(ledPin, LOW);
+  }
+}


### PR DESCRIPTION
Adds Ethernet examples to the TCP folder. Ethernet is already supported by the library and is pretty common in the modbus world.

I'm not sure how credit should be written. I didn't really write any significant new code for this. It was mostly pulling from existing ethernet examples.