### PR TITLE
Use GitHub Actions for CI

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,0 +1,80 @@
+name: Compile Examples
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/compile-examples.yml"
+      - "examples/**"
+      - "src/**"
+  push:
+    paths:
+      - ".github/workflows/compile-examples.yml"
+      - "examples/**"
+      - "src/**"
+  schedule:
+    # run every Tuesday at 3 AM UTC to catch breakage caused by changes to external dependencies (libraries, platforms)
+    - cron: "0 3 * * 2"
+  # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#workflow_dispatch
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      # Libraries to install for all boards
+      UNIVERSAL_LIBRARIES: |
+        # Install the ArduinoModbus library from the local path
+        - source-path: ./
+        - name: ArduinoRS485
+      UNIVERSAL_SKETCH_PATHS: |
+        - examples/RTU
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        board:
+          - fqbn: arduino:avr:nano
+            nina: false
+          - fqbn: arduino:avr:leonardo
+            nina: false
+          - fqbn: arduino:megaavr:uno2018:mode=off
+            nina: true
+          - fqbn: arduino:samd:mkrwifi1010
+            nina: true
+          - fqbn: arduino:mbed:nano33ble
+            nina: false
+          - fqbn: arduino:mbed:envie_m7
+            nina: false
+
+        # Make board type-specific customizations to the matrix jobs
+        include:
+          - board:
+              # Boards with NINA-W102 module
+              nina: true
+            # Install these libraries in addition to the ones defined by env.UNIVERSAL_LIBRARIES
+            nina-libraries: |
+              - name: WiFiNINA
+            # Compile these sketches in addition to the ones defined by env.UNIVERSAL_SKETCH_PATHS
+            nina-sketch-paths: |
+              - examples/TCP
+          - board:
+              nina: false
+            nina-libraries: ""
+            nina-sketch-paths: ""
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Compile examples
+        uses: arduino/compile-sketches@main
+        with:
+          fqbn: ${{ matrix.board.fqbn }}
+          libraries: |
+            ${{ env.UNIVERSAL_LIBRARIES }}
+            ${{ matrix.nina-libraries }}
+          sketch-paths: |
+            ${{ env.UNIVERSAL_SKETCH_PATHS }}
+            ${{ matrix.nina-sketch-paths }}

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
+      SKETCHES_REPORTS_PATH: sketches-reports
       # Libraries to install for all boards
       UNIVERSAL_LIBRARIES: |
         # Install the ArduinoModbus library from the local path
@@ -78,3 +79,11 @@ jobs:
           sketch-paths: |
             ${{ env.UNIVERSAL_SKETCH_PATHS }}
             ${{ matrix.nina-sketch-paths }}
+          enable-deltas-report: true
+          sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
+
+      - name: Save memory usage change report as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.SKETCHES_REPORTS_PATH }}
+          path: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -1,0 +1,18 @@
+name: Report Size Deltas
+
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+  # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#workflow_dispatch
+  workflow_dispatch:
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Comment size deltas reports to PRs
+        uses: arduino/report-size-deltas@main
+        with:
+          # The name of the workflow artifact created by the "Compile Examples" workflow
+          sketches-reports-source: sketches-reports

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,26 @@
+name: Spell Check
+
+on:
+  pull_request:
+  push:
+  schedule:
+    # run every Tuesday at 3 AM UTC
+    - cron: "0 3 * * 2"
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # See: https://github.com/codespell-project/actions-codespell/blob/master/README.md
+      - name: Spell check
+        uses: codespell-project/actions-codespell@master
+        with:
+          check_filenames: true
+          check_hidden: true
+          # In the event of a false positive, add the word in all lower case to this file:
+          ignore_words_file: extras/codespell-ignore-words-list.txt
+          skip: ./.git,./src/libmodbus

--- a/README.adoc
+++ b/README.adoc
@@ -5,6 +5,7 @@
 = Modbus Library for Arduino =
 
 image:https://github.com/{repository-owner}/{repository-name}/workflows/Compile%20Examples/badge.svg["Compile Examples Status", link="https://github.com/{repository-owner}/{repository-name}/actions?workflow=Compile+Examples"]
+image:https://github.com/{repository-owner}/{repository-name}/workflows/Spell%20Check/badge.svg["Spell Check Status", link="https://github.com/{repository-owner}/{repository-name}/actions?workflow=Spell+Check"]
 
 Use http://www.modbus.org/[Modbus] with your Arduino. 
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,10 @@
+// Define the repository information in these attributes
+:repository-owner: arduino-libraries
+:repository-name: ArduinoModbus
+
 = Modbus Library for Arduino =
+
+image:https://github.com/{repository-owner}/{repository-name}/workflows/Compile%20Examples/badge.svg["Compile Examples Status", link="https://github.com/{repository-owner}/{repository-name}/actions?workflow=Compile+Examples"]
 
 Use http://www.modbus.org/[Modbus] with your Arduino. 
 

--- a/examples/RTU/ModbusRTUClientKitchenSink/ModbusRTUClientKitchenSink.ino
+++ b/examples/RTU/ModbusRTUClientKitchenSink/ModbusRTUClientKitchenSink.ino
@@ -1,7 +1,7 @@
 /*
   Modbus RTU Client Kitchen Sink
 
-  This sketch creates a Modbus RTU Client and demostrates
+  This sketch creates a Modbus RTU Client and demonstrates
   how to use various Modbus Client APIs.
 
   Circuit:
@@ -164,7 +164,7 @@ void readHoldingRegisterValues() {
 void readInputRegisterValues() {
   Serial.print("Reading input register values ... ");
 
-  // read 10 dsicrete input values from (slave) id 42,
+  // read 10 discrete input values from (slave) id 42,
   if (!ModbusRTUClient.requestFrom(42, INPUT_REGISTERS, 0x00, 10)) {
     Serial.print("failed! ");
     Serial.println(ModbusRTUClient.lastError());
@@ -181,4 +181,3 @@ void readInputRegisterValues() {
   // Alternatively, to read a single Input Register value use:
   // ModbusRTUClient.inputRegisterRead(...)
 }
-

--- a/examples/RTU/ModbusRTUServerKitchenSink/ModbusRTUServerKitchenSink.ino
+++ b/examples/RTU/ModbusRTUServerKitchenSink/ModbusRTUServerKitchenSink.ino
@@ -1,7 +1,7 @@
 /*
   Modbus RTU Server Kitchen Sink
 
-  This sketch creates a Modbus RTU Server and demostrates
+  This sketch creates a Modbus RTU Server and demonstrates
   how to use various Modbus Server APIs.
 
   Circuit:
@@ -62,7 +62,7 @@ void loop() {
     ModbusRTUServer.discreteInputWrite(i, coilValue);
   }
 
-  // map the holiding register values to the input register values
+  // map the holding register values to the input register values
   for (int i = 0; i < numHoldingRegisters; i++) {
     long holdingRegisterValue = ModbusRTUServer.holdingRegisterRead(i);
 

--- a/examples/RTU/ModbusRTUServerLED/ModbusRTUServerLED.ino
+++ b/examples/RTU/ModbusRTUServerLED/ModbusRTUServerLED.ino
@@ -53,7 +53,7 @@ void loop() {
     // coil value set, turn LED on
     digitalWrite(ledPin, HIGH);
   } else {
-    // coild value clear, turn LED off
+    // coil value clear, turn LED off
     digitalWrite(ledPin, LOW);
   }
 }

--- a/examples/RTU/ModbusRTUTemperatureSensor/ModbusRTUTemperatureSensor.ino
+++ b/examples/RTU/ModbusRTUTemperatureSensor/ModbusRTUTemperatureSensor.ino
@@ -1,5 +1,5 @@
 /*
-  Modbus RTU Temeperature Sensor
+  Modbus RTU Temperature Sensor
 
   This sketch shows you how to interact with a Modbus RTU temperature and humidity sensor.
   It reads the temperature and humidity values every 5 seconds and outputs them to the

--- a/examples/TCP/WiFiModbusClientToggle/WiFiModbusClientToggle.ino
+++ b/examples/TCP/WiFiModbusClientToggle/WiFiModbusClientToggle.ino
@@ -40,7 +40,7 @@ void setup() {
 
   Serial.println("Modbus TCP Client Toggle");
 
-  // attempt to connect to Wifi network:
+  // attempt to connect to WiFi network:
   while (status != WL_CONNECTED) {
     Serial.print("Attempting to connect to SSID: ");
     Serial.println(ssid);

--- a/examples/TCP/WiFiModbusServerLED/WiFiModbusServerLED.ino
+++ b/examples/TCP/WiFiModbusServerLED/WiFiModbusServerLED.ino
@@ -41,7 +41,7 @@ void setup() {
 
   Serial.println("Modbus TCP Server LED");
 
-  // attempt to connect to Wifi network:
+  // attempt to connect to WiFi network:
   while (status != WL_CONNECTED) {
     Serial.print("Attempting to connect to SSID: ");
     Serial.println(ssid);

--- a/src/ModbusClient.h
+++ b/src/ModbusClient.h
@@ -65,7 +65,7 @@ public:
    * @param id (slave) id of target, defaults to 0x00 if not specified
    * @param address start address to use for operation
    *
-   * @return holiding register value on success, -1 on failure.
+   * @return holding register value on success, -1 on failure.
    */
   long holdingRegisterRead(int address);
   long holdingRegisterRead(int id, int address);


### PR DESCRIPTION
On every push and pull request, use [the `arduino/compile-sketches` action](https://github.com/arduino/compile-sketches) to compile the example sketches for the same list of boards.

On creation or commit to a pull request, use [the `arduino/report-size-deltas` action](https://github.com/arduino/report-size-deltas) to comment a report of the resulting change in memory usage of the examples to the PR thread.

On every push, pull request, and periodically, use [the `codespell-project/actions-codespell` action](https://github.com/codespell-project/actions-codespell) to check for commonly misspelled words. In the event of a false positive, the problematic word should be added, in all lowercase, to
extras/codespell-ignore-words-list.txt, after which it will be ignored by the action.

---
Note: I believe the compilation failures are genuine rather than a misconfiguration of the workflow.

---
- Fixes https://github.com/arduino-libraries/ArduinoModbus/issues/42