### PR TITLE
added methods to configure modbus server to existing data stuctures

### DIFF
--- a/examples/TCP/EthernetModbusServerPointerMapping/EthernetModbusServerPointerMapping.ino
+++ b/examples/TCP/EthernetModbusServerPointerMapping/EthernetModbusServerPointerMapping.ino
@@ -1,0 +1,129 @@
+/*
+  Ethernet Modbus TCP Server LED using existing varibles as modbus memory
+
+  This sketch creates a Modbus TCP Server with a simulated coil.
+  The value of the simulated coil is set on the LED
+
+  Circuit:
+   - Any Arduino MKR Board
+   - MKR ETH Shield
+
+  created 16 July 2018
+  by Sandeep Mistry
+*/
+
+#include <SPI.h>
+#include <Ethernet.h>
+
+#include <ArduinoRS485.h> // ArduinoModbus depends on the ArduinoRS485 library
+#include <ArduinoModbus.h>
+
+// Enter a MAC address for your controller below.
+// Newer Ethernet shields have a MAC address printed on a sticker on the shield
+// The IP address will be dependent on your local network:
+byte mac[] = {
+  0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED
+};
+IPAddress ip(192, 168, 1, 177);
+
+EthernetServer ethServer(502);
+
+ModbusTCPServer modbusTCPServer;
+
+const int ledPin = LED_BUILTIN;
+
+//create an example struct of a modbus memory map
+struct mb_context{
+	uint8_t coils[10];
+	uint8_t inputStats[10];
+	uint16_t inputRegs[10];
+	uint16_t holdingRegs[10];
+};
+
+mb_context myModbusMap;
+
+void updateLED() {
+	// read the current value of the coil
+	
+
+	if (myModbusMap.coils[0]) {
+		// coil value set, turn LED on
+		digitalWrite(ledPin, HIGH);
+		} else {
+		// coild value clear, turn LED off
+		digitalWrite(ledPin, LOW);
+	}
+}
+
+void setup() {
+  // You can use Ethernet.init(pin) to configure the CS pin
+  //Ethernet.init(10);  // Most Arduino shields
+  //Ethernet.init(5);   // MKR ETH shield
+  //Ethernet.init(0);   // Teensy 2.0
+  //Ethernet.init(20);  // Teensy++ 2.0
+  //Ethernet.init(15);  // ESP8266 with Adafruit Featherwing Ethernet
+  //Ethernet.init(33);  // ESP32 with Adafruit Featherwing Ethernet
+
+  // Open serial communications and wait for port to open:
+  Serial.begin(9600);
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for native USB port only
+  }
+  Serial.println("Ethernet Modbus TCP Example");
+
+  // start the Ethernet connection and the server:
+  Ethernet.begin(mac, ip);
+
+  // Check for Ethernet hardware present
+  if (Ethernet.hardwareStatus() == EthernetNoHardware) {
+    Serial.println("Ethernet shield was not found.  Sorry, can't run without hardware. :(");
+    while (true) {
+      delay(1); // do nothing, no point running without Ethernet hardware
+    }
+  }
+  if (Ethernet.linkStatus() == LinkOFF) {
+    Serial.println("Ethernet cable is not connected.");
+  }
+
+  // start the server
+  ethServer.begin();
+  
+  // start the Modbus TCP server
+  if (!modbusTCPServer.begin()) {
+    Serial.println("Failed to start Modbus TCP Server!");
+    while (1);
+  }
+
+  // configure the LED
+  pinMode(ledPin, OUTPUT);
+  digitalWrite(ledPin, LOW);
+
+  // configure a each modbus table's pointer and length
+  modbusTCPServer.configureCoilPointer(myModbusMap.coils, 0x00, 10);
+  modbusTCPServer.configureDiscreteInputPointer(myModbusMap.inputStats, 0x00, 10);
+  modbusTCPServer.configureInputRegisterPointer(myModbusMap.inputRegs, 0x00, 10);
+  modbusTCPServer.configureHoldingRegisterPointer(myModbusMap.holdingRegs, 0x00, 10);
+}
+
+void loop() {
+  // listen for incoming clients
+  EthernetClient client = ethServer.available();
+  
+  if (client) {
+    // a new client connected
+    Serial.println("new client");
+
+    // let the Modbus TCP accept the connection 
+    modbusTCPServer.accept(client);
+
+    while (client.connected()) {
+      // poll for Modbus TCP requests, while client connected
+      modbusTCPServer.poll();
+
+      // update the LED
+      updateLED();
+    }
+
+    Serial.println("client disconnected");
+  }
+}

--- a/src/ModbusServer.cpp
+++ b/src/ModbusServer.cpp
@@ -50,6 +50,21 @@ ModbusServer::~ModbusServer()
   }
 }
 
+int ModbusServer::configureCoilPointer(uint8_t *ptr, int startAddress, int nb)
+{
+  if (startAddress < 0 || nb < 1) {
+    errno = EINVAL;
+
+    return -1;
+  }
+
+  _mbMapping.tab_bits = ptr;
+  _mbMapping.start_bits = startAddress;
+  _mbMapping.nb_bits = nb;
+
+  return 1;
+}
+
 int ModbusServer::configureCoils(int startAddress, int nb)
 {
   if (startAddress < 0 || nb < 1) {
@@ -72,6 +87,20 @@ int ModbusServer::configureCoils(int startAddress, int nb)
   memset(_mbMapping.tab_bits, 0x00, s);
   _mbMapping.start_bits = startAddress;
   _mbMapping.nb_bits = nb;
+
+  return 1;
+}
+
+int ModbusServer::configureDiscreteInputPointer(uint8_t *ptr, int startAddress, int nb)
+{
+  if (startAddress < 0 || nb < 1) {
+    errno = EINVAL;
+
+    return -1;
+  }
+  _mbMapping.tab_input_bits = ptr;
+  _mbMapping.start_input_bits = startAddress;
+  _mbMapping.nb_input_bits = nb;
 
   return 1;
 }
@@ -102,6 +131,20 @@ int ModbusServer::configureDiscreteInputs(int startAddress, int nb)
   return 1;
 }
 
+
+int ModbusServer::configureHoldingRegisterPointer(uint16_t *ptr, int startAddress, int nb)
+{
+  if (startAddress < 0 || nb < 1) {
+    errno = EINVAL;
+
+    return -1;
+  }
+  _mbMapping.tab_registers = ptr;
+  _mbMapping.start_registers = startAddress;
+  _mbMapping.nb_registers = nb;
+  return 1;  
+}
+
 int ModbusServer::configureHoldingRegisters(int startAddress, int nb)
 {
   if (startAddress < 0 || nb < 1) {
@@ -124,6 +167,20 @@ int ModbusServer::configureHoldingRegisters(int startAddress, int nb)
   memset(_mbMapping.tab_registers, 0x00, s);
   _mbMapping.start_registers = startAddress;
   _mbMapping.nb_registers = nb;
+
+  return 1;
+}
+
+int ModbusServer::configureInputRegisterPointer(uint16_t *ptr, int startAddress, int nb)
+{
+  if (startAddress < 0 || nb < 1) {
+    errno = EINVAL;
+
+    return -1;
+  }
+  _mbMapping.tab_input_registers = ptr;
+  _mbMapping.start_input_registers = startAddress;
+  _mbMapping.nb_input_registers = nb;
 
   return 1;
 }

--- a/src/ModbusServer.h
+++ b/src/ModbusServer.h
@@ -30,6 +30,16 @@ class ModbusServer {
 
 public:
   /**
+   * Configure the servers coil starting address.
+   *
+   * @param ptr pointer address of existing data struct
+   * @param startAddress start address of holding registers
+   * @param nb number of holding registers to configure
+   *
+   * @return 0 on success, 1 on failure
+   */
+  int configureCoilPointer(uint8_t *ptr, int startAddress, int nb);
+  /**
    * Configure the servers coils.
    *
    * @param startAddress start address of coils
@@ -38,7 +48,16 @@ public:
    * @return 0 on success, 1 on failure
    */
   int configureCoils(int startAddress, int nb);
-
+  /**
+   * Configure the servers discrete inputs starting address.
+   *
+   * @param ptr pointer address of existing data struct
+   * @param startAddress start address of holding registers
+   * @param nb number of holding registers to configure
+   *
+   * @return 0 on success, 1 on failure
+   */
+  int configureDiscreteInputPointer(uint8_t *ptr, int startAddress, int nb);
   /**
    * Configure the servers discrete inputs.
    *
@@ -49,6 +68,19 @@ public:
    */
   int configureDiscreteInputs(int startAddress, int nb);
 
+
+  /**
+   * Configure the servers holding registers starting address.
+   *
+   * @param ptr pointer address of existing data struct
+   * @param startAddress start address of holding registers
+   * @param nb number of holding registers to configure
+   *
+   * @return 0 on success, 1 on failure
+   */
+  int configureHoldingRegisterPointer(uint16_t *ptr, int startAddress, int nb);
+
+
   /**
    * Configure the servers holding registers.
    *
@@ -56,8 +88,19 @@ public:
    * @param nb number of holding registers to configure
    *
    * @return 0 on success, 1 on failure
-   */
+   */  
   int configureHoldingRegisters(int startAddress, int nb);
+  
+    /**
+   * Configure the servers input registers starting address.
+   *
+   * @param ptr pointer address of existing data struct
+   * @param startAddress start address of holding registers
+   * @param nb number of holding registers to configure
+   *
+   * @return 0 on success, 1 on failure
+   */
+  int configureInputRegisterPointer(uint16_t *ptr, int startAddress, int nb);
 
   /**
    * Configure the servers input registers.
@@ -67,6 +110,7 @@ public:
    *
    * @return 0 on success, 1 on failure
    */
+  
   int configureInputRegisters(int startAddress, int nb);
 
   // same as ModbusClient.h


### PR DESCRIPTION
With memory being tight on most micro controllers, I felt like I shouldn't have to allocate memory for modbus to use, but instead point the server at existing data structures. If the structures are not of the same type, the user can cast it as such. 