### PR TITLE
Make RS485Class a configurable argument for ModbusRTU*

### DIFF
--- a/src/ModbusRTUClient.cpp
+++ b/src/ModbusRTUClient.cpp
@@ -31,19 +31,30 @@ ModbusRTUClientClass::ModbusRTUClientClass() :
 {
 }
 
+ModbusRTUClientClass::ModbusRTUClientClass(RS485Class& rs485) :
+  _rs485(&rs485), ModbusClient(1000)
+{
+}
+
 ModbusRTUClientClass::~ModbusRTUClientClass()
 {
 }
 
 int ModbusRTUClientClass::begin(unsigned long baudrate, uint16_t config)
 {
-  modbus_t* mb = modbus_new_rtu(baudrate, config);
+  modbus_t* mb = modbus_new_rtu(_rs485, baudrate, config);
 
   if (!ModbusClient::begin(mb, 0x00)) {
     return 0;
   }
 
   return 1;
+}
+
+int ModbusRTUClientClass::begin(RS485Class& rs485, unsigned long baudrate, uint16_t config)
+{
+  _rs485 = &rs485;
+  return begin(baudrate, config);
 }
 
 ModbusRTUClientClass ModbusRTUClient;

--- a/src/ModbusRTUClient.h
+++ b/src/ModbusRTUClient.h
@@ -21,10 +21,12 @@
 #define _MODBUS_RTU_CLIENT_H_INCLUDED
 
 #include "ModbusClient.h"
+#include <ArduinoRS485.h>
 
 class ModbusRTUClientClass : public ModbusClient {
 public:
   ModbusRTUClientClass();
+  ModbusRTUClientClass(RS485Class& rs485);
   virtual ~ModbusRTUClientClass();
 
   /**
@@ -36,6 +38,10 @@ public:
    * Return 1 on success, 0 on failure
    */
   int begin(unsigned long baudrate, uint16_t config = SERIAL_8N1);
+  int begin(RS485Class& rs485, unsigned long baudrate, uint16_t config = SERIAL_8N1);
+
+private:
+  RS485Class* _rs485;
 };
 
 extern ModbusRTUClientClass ModbusRTUClient;

--- a/src/ModbusRTUServer.cpp
+++ b/src/ModbusRTUServer.cpp
@@ -30,13 +30,17 @@ ModbusRTUServerClass::ModbusRTUServerClass()
 {
 }
 
+ModbusRTUServerClass::ModbusRTUServerClass(RS485Class& rs485) : _rs485(&rs485)
+{
+}
+
 ModbusRTUServerClass::~ModbusRTUServerClass()
 {
 }
 
 int ModbusRTUServerClass::begin(int id, unsigned long baudrate, uint16_t config)
 {
-  modbus_t* mb = modbus_new_rtu(baudrate, config);
+  modbus_t* mb = modbus_new_rtu(_rs485, baudrate, config);
 
   if (!ModbusServer::begin(mb, id)) {
     return 0;
@@ -45,6 +49,12 @@ int ModbusRTUServerClass::begin(int id, unsigned long baudrate, uint16_t config)
   modbus_connect(mb);
 
   return 1;
+}
+
+int ModbusRTUServerClass::begin(RS485Class& rs485, int id, unsigned long baudrate, uint16_t config)
+{
+  _rs485 = &rs485;
+  return begin(id, baudrate, config);
 }
 
 void ModbusRTUServerClass::poll()

--- a/src/ModbusRTUServer.h
+++ b/src/ModbusRTUServer.h
@@ -21,10 +21,12 @@
 #define _MODBUS_RTU_SERVER_H_INCLUDED
 
 #include "ModbusServer.h"
+#include <ArduinoRS485.h>
 
 class ModbusRTUServerClass : public ModbusServer {
 public:
   ModbusRTUServerClass();
+  ModbusRTUServerClass(RS485Class& rs485);
   virtual ~ModbusRTUServerClass();
 
   /**
@@ -37,11 +39,15 @@ public:
    * Return 1 on success, 0 on failure
    */
   int begin(int id, unsigned long baudrate, uint16_t config = SERIAL_8N1);
+  int begin(RS485Class& rs485, int id, unsigned long baudrate, uint16_t config = SERIAL_8N1);
 
   /**
    * Poll interface for requests
    */
   virtual void poll();
+
+private:
+  RS485Class* _rs485 = &RS485;
 };
 
 extern ModbusRTUServerClass ModbusRTUServer;

--- a/src/libmodbus/modbus-rtu-private.h
+++ b/src/libmodbus/modbus-rtu-private.h
@@ -17,7 +17,7 @@
 #if defined(_WIN32)
 #include <windows.h>
 #elif defined(ARDUINO)
-// nothing extra needed
+#include <ArduinoRS485.h>
 #else
 #include <termios.h>
 #endif
@@ -49,6 +49,7 @@ typedef struct _modbus_rtu {
 #if defined(ARDUINO)
     unsigned long baud;
     uint16_t config;
+    RS485Class* rs485;
 #else
     /* Device: "/dev/ttyS0", "/dev/ttyUSB0" or "/dev/tty.USA19*" on Mac OS X. */
     char *device;

--- a/src/libmodbus/modbus-rtu.cpp
+++ b/src/libmodbus/modbus-rtu.cpp
@@ -323,15 +323,15 @@ static ssize_t _modbus_rtu_send(modbus_t *ctx, const uint8_t *req, int req_lengt
     DWORD n_bytes = 0;
     return (WriteFile(ctx_rtu->w_ser.fd, req, req_length, &n_bytes, NULL)) ? (ssize_t)n_bytes : -1;
 #elif defined(ARDUINO)
-    (void)ctx;
+    modbus_rtu_t *ctx_rtu = (modbus_rtu_t*)ctx->backend_data;
 
     ssize_t size;
 
-    RS485.noReceive();
-    RS485.beginTransmission();
-    size = RS485.write(req, req_length);
-    RS485.endTransmission();
-    RS485.receive();
+    ctx_rtu->rs485->noReceive();
+    ctx_rtu->rs485->beginTransmission();
+    size = ctx_rtu->rs485->write(req, req_length);
+    ctx_rtu->rs485->endTransmission();
+    ctx_rtu->rs485->receive();
 
     return size;
 #else
@@ -394,9 +394,9 @@ static ssize_t _modbus_rtu_recv(modbus_t *ctx, uint8_t *rsp, int rsp_length)
 #if defined(_WIN32)
     return win32_ser_read(&((modbus_rtu_t *)ctx->backend_data)->w_ser, rsp, rsp_length);
 #elif defined(ARDUINO)
-    (void)ctx;
+    modbus_rtu_t *ctx_rtu = (modbus_rtu_t*)ctx->backend_data;
 
-    return RS485.readBytes(rsp, rsp_length);
+    return ctx_rtu->rs485->readBytes(rsp, rsp_length);
 #else
     return read(ctx->s, rsp, rsp_length);
 #endif
@@ -654,8 +654,8 @@ static int _modbus_rtu_connect(modbus_t *ctx)
         return -1;
     }
 #elif defined(ARDUINO)
-    RS485.begin(ctx_rtu->baud, ctx_rtu->config);
-    RS485.receive();
+    ctx_rtu->rs485->begin(ctx_rtu->baud, ctx_rtu->config);
+    ctx_rtu->rs485->receive();
 #else
     /* The O_NOCTTY flag tells UNIX that this program doesn't want
        to be the "controlling terminal" for that port. If you
@@ -1210,8 +1210,8 @@ static void _modbus_rtu_close(modbus_t *ctx)
 #elif defined(ARDUINO)
     (void)ctx_rtu;
 
-    RS485.noReceive();
-    RS485.end();
+    ctx_rtu->rs485->noReceive();
+    ctx_rtu->rs485->end();
 #else
     if (ctx->s != -1) {
         tcsetattr(ctx->s, TCSANOW, &ctx_rtu->old_tios);
@@ -1228,10 +1228,10 @@ static int _modbus_rtu_flush(modbus_t *ctx)
     ctx_rtu->w_ser.n_bytes = 0;
     return (PurgeComm(ctx_rtu->w_ser.fd, PURGE_RXCLEAR) == FALSE);
 #elif defined(ARDUINO)
-    (void)ctx;
+    modbus_rtu_t *ctx_rtu = (modbus_rtu_t*)ctx->backend_data;
 
-    while (RS485.available()) {
-        RS485.read();
+    while (ctx_rtu->rs485->available()) {
+        ctx_rtu->rs485->read();
     }
 
     return 0;
@@ -1256,14 +1256,14 @@ static int _modbus_rtu_select(modbus_t *ctx, fd_set *rset,
         return -1;
     }
 #elif defined(ARDUINO)
-    (void)ctx;
+    modbus_rtu_t *ctx_rtu = (modbus_rtu_t*)ctx->backend_data;
     (void)rset;
 
     unsigned long wait_time_millis = (tv == NULL) ? 0 : (tv->tv_sec * 1000) + (tv->tv_usec / 1000);
     unsigned long start = millis();
 
     do {
-        s_rc = RS485.available();
+        s_rc = ctx_rtu->rs485->available();
 
         if (s_rc >= length_to_read) {
             break;
@@ -1330,7 +1330,7 @@ const modbus_backend_t _modbus_rtu_backend = {
 };
 
 #ifdef ARDUINO
-modbus_t* modbus_new_rtu(unsigned long baud, uint16_t config)
+modbus_t* modbus_new_rtu(RS485Class *rs485, unsigned long baud, uint16_t config)
 #else
 modbus_t* modbus_new_rtu(const char *device,
                          int baud, char parity, int data_bit,
@@ -1362,6 +1362,7 @@ modbus_t* modbus_new_rtu(const char *device,
     ctx->backend_data = (modbus_rtu_t *)malloc(sizeof(modbus_rtu_t));
     ctx_rtu = (modbus_rtu_t *)ctx->backend_data;
 #ifdef ARDUINO
+    ctx_rtu->rs485 = rs485;
     ctx_rtu->baud = baud;
     ctx_rtu->config = config;
 #else

--- a/src/libmodbus/modbus-rtu.h
+++ b/src/libmodbus/modbus-rtu.h
@@ -18,7 +18,8 @@ MODBUS_BEGIN_DECLS
 #define MODBUS_RTU_MAX_ADU_LENGTH  256
 
 #ifdef ARDUINO
-MODBUS_API modbus_t* modbus_new_rtu(unsigned long baud, uint16_t config);
+class RS485Class;
+MODBUS_API modbus_t* modbus_new_rtu(RS485Class *rs485, unsigned long baud, uint16_t config);
 #else
 MODBUS_API modbus_t* modbus_new_rtu(const char *device, int baud, char parity,
                                     int data_bit, int stop_bit);


### PR DESCRIPTION
Can be changed by either the constructor or begin()

Ports and replaces https://github.com/arduino-libraries/ArduinoModbus/pull/14