### PR TITLE
Return flag from poll() to allow conditional events to trigger

### DIFF
--- a/examples/RTU/ModbusRTUServerLED/ModbusRTUServerLED.ino
+++ b/examples/RTU/ModbusRTUServerLED/ModbusRTUServerLED.ino
@@ -44,16 +44,18 @@ void setup() {
 
 void loop() {
   // poll for Modbus RTU requests
-  ModbusRTUServer.poll();
+  int packetReceived = ModbusRTUServer.poll();
 
-  // read the current value of the coil
-  int coilValue = ModbusRTUServer.coilRead(0x00);
-
-  if (coilValue) {
-    // coil value set, turn LED on
-    digitalWrite(ledPin, HIGH);
-  } else {
-    // coil value clear, turn LED off
-    digitalWrite(ledPin, LOW);
+  if(packetReceived) {
+    // read the current value of the coil
+    int coilValue = ModbusRTUServer.coilRead(0x00);
+  
+    if (coilValue) {
+      // coil value set, turn LED on
+      digitalWrite(ledPin, HIGH);
+    } else {
+      // coil value clear, turn LED off
+      digitalWrite(ledPin, LOW);
+    }
   }
 }

--- a/src/ModbusRTUServer.cpp
+++ b/src/ModbusRTUServer.cpp
@@ -57,7 +57,7 @@ int ModbusRTUServerClass::begin(RS485Class& rs485, int id, unsigned long baudrat
   return begin(id, baudrate, config);
 }
 
-void ModbusRTUServerClass::poll()
+int ModbusRTUServerClass::poll()
 {
   uint8_t request[MODBUS_RTU_MAX_ADU_LENGTH];
 
@@ -65,7 +65,9 @@ void ModbusRTUServerClass::poll()
 
   if (requestLength > 0) {
     modbus_reply(_mb, request, requestLength, &_mbMapping);
+    return 1;
   }
+  return 0;
 }
 
 ModbusRTUServerClass ModbusRTUServer;

--- a/src/ModbusRTUServer.h
+++ b/src/ModbusRTUServer.h
@@ -44,7 +44,7 @@ public:
   /**
    * Poll interface for requests
    */
-  virtual void poll();
+  virtual int poll();
 
 private:
   RS485Class* _rs485 = &RS485;

--- a/src/ModbusServer.h
+++ b/src/ModbusServer.h
@@ -126,8 +126,10 @@ public:
 
   /**
    * Poll for requests
+   * 
+   * @return 1 on request, 0 on no request.
    */
-  virtual void poll() = 0;
+  virtual int poll() = 0;
 
   /**
    * Stop the server

--- a/src/ModbusTCPServer.cpp
+++ b/src/ModbusTCPServer.cpp
@@ -57,7 +57,7 @@ void ModbusTCPServer::accept(Client& client)
   }
 }
 
-void ModbusTCPServer::poll()
+int ModbusTCPServer::poll()
 {
   if (_client != NULL) {
     uint8_t request[MODBUS_TCP_MAX_ADU_LENGTH];
@@ -66,6 +66,8 @@ void ModbusTCPServer::poll()
 
     if (requestLength > 0) {
       modbus_reply(_mb, request, requestLength, &_mbMapping);
+      return 1;
     }
   }
+  return 0;
 }

--- a/src/ModbusTCPServer.h
+++ b/src/ModbusTCPServer.h
@@ -48,7 +48,7 @@ public:
   /**
    * Poll accepted client for requests
    */
-  virtual void poll();
+  virtual int poll();
 
 private:
   Client* _client;


### PR DESCRIPTION
Returning a flag from server's poll() is helpful to allow code conditionally execute when a new packet is received. For example, we may want to update holding registers after the last values were collected by the client. Using the flag is optional and can be ignored, using poll() as it has been.