### PR TITLE
Add Arduino.h back

### DIFF
--- a/src/libmodbus/modbus.c
+++ b/src/libmodbus/modbus.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #endif
 #ifdef ARDUINO
+#include <Arduino.h>
 
 #ifndef DEBUG
 #define printf(...) {}

--- a/src/libmodbus/modbus.c
+++ b/src/libmodbus/modbus.c
@@ -19,7 +19,6 @@
 #include <unistd.h>
 #endif
 #ifdef ARDUINO
-#include <Arduino.h>
 
 #ifndef DEBUG
 #define printf(...) {}
@@ -49,6 +48,11 @@
 
 #undef ENOTSUP
 #define ENOTSUP 134
+#endif
+
+/* workaround for stm32duino delay and delayMicroseconds */
+#ifdef ARDUINO_ARCH_STM32
+#include <wiring_time.h>
 #endif
 
 #include "modbus.h"


### PR DESCRIPTION
Removing Arduino.h causes compile issues on stm32duino so adding back just the needed dependency.

Here is the definition of delayMicroseconds in stm32duino https://github.com/stm32duino/Arduino_Core_STM32/blob/a7283739a4d8bafe95c9f9b9156e6f82a1ebbd75/cores/arduino/wiring_time.h#L64

this breaking change was introduced on https://github.com/arduino-libraries/ArduinoModbus/pull/58 pull request

```
Compiling .pio/build/universal/lib640/ArduinoModbus/libmodbus/modbus.c.o
.pio/libdeps/universal/ArduinoModbus/src/libmodbus/modbus.c: In function '_sleep_response_timeout':
.pio/libdeps/universal/ArduinoModbus/src/libmodbus/modbus.c:156:5: warning: implicit declaration of function 'delay' [-Wimplicit-function-declaration]
  156 |     delay(ctx->response_timeout.tv_sec * 1000);
      |     ^~~~~
.pio/libdeps/universal/ArduinoModbus/src/libmodbus/modbus.c:157:5: warning: implicit declaration of function 'delayMicroseconds' [-Wimplicit-function-declaration]
  157 |     delayMicroseconds(ctx->response_timeout.tv_usec);
      |     ^~~~~~~~~~~~~~~~~
Archiving .pio/build/universal/lib640/libArduinoModbus.a
Indexing .pio/build/universal/lib640/libArduinoModbus.a
Linking .pio/build/universal/firmware.elf
/home/user/.platformio/packages/toolchain-gccarmnoneeabi/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/ld: .pio/build/universal/lib640/libArduinoModbus.a(modbus.c.o): in function `_sleep_response_timeout':
modbus.c:(.text._sleep_response_timeout+0x1e): undefined reference to `delayMicroseconds'
collect2: error: ld returned 1 exit status
*** [.pio/build/universal/firmware.elf] Error 1