### PR TITLE
Fix implicit declaration compiler warnings (which are errors on some boards)

### DIFF
--- a/src/libmodbus/modbus.c
+++ b/src/libmodbus/modbus.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #endif
 #ifdef ARDUINO
+#include <Arduino.h>
 
 #ifndef DEBUG
 #define printf(...) {}


### PR DESCRIPTION
This fix might be called "trivial" but it fixes a compiler warning, and with some boards that use inline code for delayMicroseconds, it is an error rather than just a warning.