### PR TITLE
Fixed segfault when initializing TCP server. "Client" is 0 there.

### DIFF
--- a/src/libmodbus/modbus-tcp.cpp
+++ b/src/libmodbus/modbus-tcp.cpp
@@ -499,7 +499,10 @@ static void _modbus_tcp_close(modbus_t *ctx)
 #ifdef ARDUINO
     modbus_tcp_t *ctx_tcp = (modbus_tcp_t*)ctx->backend_data;
 
-    ctx_tcp->client->stop();
+    if(ctx_tcp && ctx_tcp->client) { 
+        ctx_tcp->client->stop();
+    }
+    
 #else
     if (ctx->s != -1) {
         shutdown(ctx->s, SHUT_RDWR);


### PR DESCRIPTION
Issue #75 describes a crash wne a ModbusTCPServer is initialized.
This is a fix for that issue.