### PR TITLE
Fix  define ON OFF conflict with other libraries

### DIFF
--- a/src/libmodbus/modbus.c
+++ b/src/libmodbus/modbus.c
@@ -864,7 +864,7 @@ int modbus_reply(modbus_t *ctx, const uint8_t *req,
 #else
             if (data == 0xFF00 || data == 0x0) {
 #endif
-                mb_mapping->tab_bits[mapping_address] = data ? TRUE : FALSE;
+                mb_mapping->tab_bits[mapping_address] = data ? 1 : 0;
                 memcpy(rsp, req, req_length);
                 rsp_length = req_length;
             } else {

--- a/src/libmodbus/modbus.c
+++ b/src/libmodbus/modbus.c
@@ -864,7 +864,7 @@ int modbus_reply(modbus_t *ctx, const uint8_t *req,
 #else
             if (data == 0xFF00 || data == 0x0) {
 #endif
-                mb_mapping->tab_bits[mapping_address] = data ? ON : OFF;
+                mb_mapping->tab_bits[mapping_address] = data ? TRUE : FALSE;
                 memcpy(rsp, req, req_length);
                 rsp_length = req_length;
             } else {

--- a/src/libmodbus/modbus.h
+++ b/src/libmodbus/modbus.h
@@ -50,13 +50,6 @@ MODBUS_BEGIN_DECLS
 #define TRUE 1
 #endif
 
-#ifndef OFF
-#define OFF 0
-#endif
-
-#ifndef ON
-#define ON 1
-#endif
 
 /* Modbus function codes */
 #define MODBUS_FC_READ_COILS                0x01


### PR DESCRIPTION
The #define ON and #define OFF in modbus.h creates a conflict with Arduino Menu 4 library. It is only used once in modbus.c and can be substituted for TRUE FALSE, also defined in modbus.h