### PR TITLE
Drop official support for AVR for this library.

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -39,12 +39,6 @@ jobs:
 
       matrix:
         board:
-          - fqbn: arduino:avr:nano
-            ethernet: true
-            nina: false
-          - fqbn: arduino:avr:leonardo
-            ethernet: true
-            nina: false
           - fqbn: arduino:megaavr:uno2018:mode=off
             ethernet: true
             nina: true

--- a/library.properties
+++ b/library.properties
@@ -6,6 +6,6 @@ sentence=Use Modbus equipment with your Arduino.
 paragraph=Using TCP or RS485 shields, like the MKR 485 Shield. This library depends on the ArduinoRS485 library.
 category=Communication
 url=https://www.arduino.cc/en/ArduinoModbus/ArduinoModbus
-architectures=avr,megaavr,samd,mbed_nano,mbed_portenta
+architectures=megaavr,samd,mbed_nano,mbed_portenta
 includes=ArduinoModbus.h
 depends=ArduinoRS485


### PR DESCRIPTION
This is imho necessary since even one of our own examples does not link anymore, due to the required memory exceeding the available ressources of the ATMEGA328P based Arduino Nano.