### PR TITLE
Make delay depend on number of bits per character

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -229,7 +229,7 @@ int requestFrom(int id, int type, int address,int nb);
 
 #### Parameters
 - id (slave) - id of target, defaults to 0x00 if not specified
-type - type of read to perform, either COILS, DISCRETE_INPUTS, HOLDING_REGISTERS, or INPUT_REGISTERS
+- type - type of read to perform, either COILS, DISCRETE_INPUTS, HOLDING_REGISTERS, or INPUT_REGISTERS
 - address start address to use for operation
 - nb - number of values to read
 

--- a/examples/RTU/ModbusRTUClientParameters/ModbusRTUClientParameters.ino
+++ b/examples/RTU/ModbusRTUClientParameters/ModbusRTUClientParameters.ino
@@ -22,9 +22,9 @@ constexpr auto baudrate { 19200 };
 // Paragraph 2.5.1.1 MODBUS Message RTU Framing
 // https://modbus.org/docs/Modbus_over_serial_line_V1_02.pdf
 constexpr auto bitduration { 1.f / baudrate };
-constexpr auto wordlen { 9.6f }; // try also with 10.0f
-constexpr auto preDelayBR { bitduration * wordlen * 3.5f * 1e6 };
-constexpr auto postDelayBR { bitduration * wordlen * 3.5f * 1e6 };
+constexpr auto charlen { 11.0f };
+constexpr auto preDelayBR { bitduration * charlen * 3.5f * 1e6 };
+constexpr auto postDelayBR { bitduration * charlen * 3.5f * 1e6 };
 
 void setup() {
   Serial.begin(9600);


### PR DESCRIPTION
As per specification, there should be always 11 bits transmitted for each character.