### PR TITLE
don't wait for confirmation response if the write is a broadcast message

### DIFF
--- a/src/libmodbus/modbus.c
+++ b/src/libmodbus/modbus.c
@@ -1393,7 +1393,7 @@ int modbus_write_bits(modbus_t *ctx, int addr, int nb, const uint8_t *src)
     }
 
     rc = send_msg(ctx, req, req_length);
-    if (rc > 0) {
+    if (rc > 0 && ctx->slave != 0) {
         uint8_t rsp[MAX_MESSAGE_LENGTH];
 
         rc = _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION);
@@ -1443,7 +1443,7 @@ int modbus_write_registers(modbus_t *ctx, int addr, int nb, const uint16_t *src)
     }
 
     rc = send_msg(ctx, req, req_length);
-    if (rc > 0) {
+    if (rc > 0 && ctx->slave != 0) {
         uint8_t rsp[MAX_MESSAGE_LENGTH];
 
         rc = _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION);


### PR DESCRIPTION
Fixes #117 

I added a condition `ctx->slave!=0` so that a response is not expected if its a broadcast message. This allows the `endTransmission` to return asap without blocking waiting for a response that will never come and eventually timing out.

I added this to `modbus_write_bits` and `modbus_write_registers` which are the only 2 functions called by `endTransmission`

This has fixed issue #117 for me. 

Not sure if this may need to be added in any other places?