### PR TITLE
Expose libmodbus's flush command

### DIFF
--- a/src/ModbusRTUServer.cpp
+++ b/src/ModbusRTUServer.cpp
@@ -70,4 +70,9 @@ int ModbusRTUServerClass::poll()
   return 0;
 }
 
+int ModbusRTUServerClass::flush()
+{
+  return modbus_flush(_mb);
+}
+
 ModbusRTUServerClass ModbusRTUServer;

--- a/src/ModbusRTUServer.h
+++ b/src/ModbusRTUServer.h
@@ -46,6 +46,11 @@ public:
    */
   virtual int poll();
 
+  /**
+   * Flush modbus
+   */
+  virtual int flush();
+
 private:
   RS485Class* _rs485 = &RS485;
 };


### PR DESCRIPTION
* Expose libmodbus's flush command to ModbusRTUServer API
* This command proved to be necessary for stable operation for large reads at low baud rates on the RP2040. May be important for cross-platform compatibility