### PR TITLE
Correct documentation on `ModbusServer::poll()`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -730,14 +730,14 @@ Poll for requests
 #### Syntax
 
 ```
-virtual void poll() = 0;
+virtual int poll() = 0;
 ```
 
 #### Parameters
 None
 
 #### Returns
-nothing
+1 on request, 0 on no request
 
 ### `modbusServer.end()`
 


### PR DESCRIPTION
The `ModbusServer::poll()`[1] function returns an `int`, in the docs it said it returned *nothing* (`void`). I have changed the API-documetation to match the actual function declaration and doc-comment.

I observed this on the Arduino website.[2] I have archived the Reference page with the mistake on Wayback Machine for future reference.[3]

I don't know if i have made the change in the correct file, but the mistake was the same in it, so I assume it supplies the information for the website.

In case my assumption is true: may i ask why the documentation on the website isn't auto-generated from the doc-comments in the code files?

[1]: https://github.com/arduino-libraries/ArduinoModbus/blob/master/src/ModbusServer.h#L127-L132
[2]: https://www.arduino.cc/reference/en/libraries/arduinomodbus/modbusserver.poll/
[3]: https://web.archive.org/web/20240104102142/https://www.arduino.cc/reference/en/libraries/arduinomodbus/modbusserver.poll/