### PR TITLE
Added Compatibility to ESP32 ESP8266

### DIFF
--- a/src/ModbusRTUClient.cpp
+++ b/src/ModbusRTUClient.cpp
@@ -40,7 +40,7 @@ ModbusRTUClientClass::~ModbusRTUClientClass()
 {
 }
 
-int ModbusRTUClientClass::begin(unsigned long baudrate, uint16_t config)
+int ModbusRTUClientClass::begin(unsigned long baudrate, RS485_SER_CONF_TYPE config)
 {
   modbus_t* mb = modbus_new_rtu(_rs485, baudrate, config);
 
@@ -51,7 +51,7 @@ int ModbusRTUClientClass::begin(unsigned long baudrate, uint16_t config)
   return 1;
 }
 
-int ModbusRTUClientClass::begin(RS485Class& rs485, unsigned long baudrate, uint16_t config)
+int ModbusRTUClientClass::begin(RS485Class& rs485, unsigned long baudrate, RS485_SER_CONF_TYPE config)
 {
   _rs485 = &rs485;
   return begin(baudrate, config);

--- a/src/ModbusRTUClient.h
+++ b/src/ModbusRTUClient.h
@@ -17,8 +17,14 @@
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+
 #ifndef _MODBUS_RTU_CLIENT_H_INCLUDED
 #define _MODBUS_RTU_CLIENT_H_INCLUDED
+
+#ifndef RS485_SER_CONF_TYPE
+#define RS485_SER_CONF_TYPE uint16_t
+#endif
+
 
 #include "ModbusClient.h"
 #include <ArduinoRS485.h>
@@ -37,8 +43,8 @@ public:
    *
    * Return 1 on success, 0 on failure
    */
-  int begin(unsigned long baudrate, uint16_t config = SERIAL_8N1);
-  int begin(RS485Class& rs485, unsigned long baudrate, uint16_t config = SERIAL_8N1);
+  int begin(unsigned long baudrate, RS485_SER_CONF_TYPE config = SERIAL_8N1);
+  int begin(RS485Class& rs485, unsigned long baudrate, RS485_SER_CONF_TYPE config = SERIAL_8N1);
 
 private:
   RS485Class* _rs485 = &RS485;

--- a/src/ModbusRTUServer.cpp
+++ b/src/ModbusRTUServer.cpp
@@ -38,7 +38,7 @@ ModbusRTUServerClass::~ModbusRTUServerClass()
 {
 }
 
-int ModbusRTUServerClass::begin(int id, unsigned long baudrate, uint16_t config)
+int ModbusRTUServerClass::begin(int id, unsigned long baudrate, RS485_SER_CONF_TYPE config)
 {
   modbus_t* mb = modbus_new_rtu(_rs485, baudrate, config);
 
@@ -51,7 +51,7 @@ int ModbusRTUServerClass::begin(int id, unsigned long baudrate, uint16_t config)
   return 1;
 }
 
-int ModbusRTUServerClass::begin(RS485Class& rs485, int id, unsigned long baudrate, uint16_t config)
+int ModbusRTUServerClass::begin(RS485Class& rs485, int id, unsigned long baudrate, RS485_SER_CONF_TYPE config)
 {
   _rs485 = &rs485;
   return begin(id, baudrate, config);

--- a/src/ModbusRTUServer.h
+++ b/src/ModbusRTUServer.h
@@ -17,8 +17,14 @@
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+
 #ifndef _MODBUS_RTU_SERVER_H_INCLUDED
 #define _MODBUS_RTU_SERVER_H_INCLUDED
+
+
+#ifndef RS485_SER_CONF_TYPE
+#define RS485_SER_CONF_TYPE uint16_t
+#endif
 
 #include "ModbusServer.h"
 #include <ArduinoRS485.h>
@@ -38,8 +44,8 @@ public:
    *
    * Return 1 on success, 0 on failure
    */
-  int begin(int id, unsigned long baudrate, uint16_t config = SERIAL_8N1);
-  int begin(RS485Class& rs485, int id, unsigned long baudrate, uint16_t config = SERIAL_8N1);
+  int begin(int id, unsigned long baudrate, RS485_SER_CONF_TYPE config = SERIAL_8N1);
+  int begin(RS485Class& rs485, int id, unsigned long baudrate, RS485_SER_CONF_TYPE config = SERIAL_8N1);
 
   /**
    * Poll interface for requests

--- a/src/libmodbus/modbus-rtu-private.h
+++ b/src/libmodbus/modbus-rtu-private.h
@@ -5,6 +5,11 @@
  * SPDX-License-Identifier: LGPL-2.1+
  */
 
+#ifndef RS485_SER_CONF_TYPE
+#define RS485_SER_CONF_TYPE uint16_t
+#endif
+
+
 #ifndef MODBUS_RTU_PRIVATE_H
 #define MODBUS_RTU_PRIVATE_H
 
@@ -33,6 +38,7 @@
 #define ENOTSUP WSAEOPNOTSUPP
 #endif
 
+
 /* WIN32: struct containing serial handle and a receive buffer */
 #define PY_BUF_SIZE 512
 struct win32_ser {
@@ -48,7 +54,7 @@ struct win32_ser {
 typedef struct _modbus_rtu {
 #if defined(ARDUINO)
     unsigned long baud;
-    uint16_t config;
+    RS485_SER_CONF_TYPE config;
     RS485Class* rs485;
 #else
     /* Device: "/dev/ttyS0", "/dev/ttyUSB0" or "/dev/tty.USA19*" on Mac OS X. */

--- a/src/libmodbus/modbus-rtu.cpp
+++ b/src/libmodbus/modbus-rtu.cpp
@@ -654,7 +654,11 @@ static int _modbus_rtu_connect(modbus_t *ctx)
         return -1;
     }
 #elif defined(ARDUINO)
+#if defined(ESP32) || defined(ESP8266)
+    ctx_rtu->rs485->begin(ctx_rtu->baud, static_cast<SerialConfig>(ctx_rtu->config));
+#else
     ctx_rtu->rs485->begin(ctx_rtu->baud, ctx_rtu->config);
+#endif
     ctx_rtu->rs485->receive();
 #else
     /* The O_NOCTTY flag tells UNIX that this program doesn't want
@@ -1330,7 +1334,7 @@ const modbus_backend_t _modbus_rtu_backend = {
 };
 
 #ifdef ARDUINO
-modbus_t* modbus_new_rtu(RS485Class *rs485, unsigned long baud, uint16_t config)
+modbus_t* modbus_new_rtu(RS485Class *rs485, unsigned long baud, RS485_SER_CONF_TYPE config)
 #else
 modbus_t* modbus_new_rtu(const char *device,
                          int baud, char parity, int data_bit,

--- a/src/libmodbus/modbus-rtu.h
+++ b/src/libmodbus/modbus-rtu.h
@@ -10,6 +10,12 @@
 
 #include "modbus.h"
 
+#if defined(ESP32) || defined(ESP8266)
+#define RS485_SER_CONF_TYPE uint32_t
+#else
+#define RS485_SER_CONF_TYPE uint16_t
+#endif
+
 MODBUS_BEGIN_DECLS
 
 /* Modbus_Application_Protocol_V1_1b.pdf Chapter 4 Section 1 Page 5
@@ -19,7 +25,7 @@ MODBUS_BEGIN_DECLS
 
 #ifdef ARDUINO
 class RS485Class;
-MODBUS_API modbus_t* modbus_new_rtu(RS485Class *rs485, unsigned long baud, uint16_t config);
+MODBUS_API modbus_t* modbus_new_rtu(RS485Class *rs485, unsigned long baud, RS485_SER_CONF_TYPE config);
 #else
 MODBUS_API modbus_t* modbus_new_rtu(const char *device, int baud, char parity,
                                     int data_bit, int stop_bit);


### PR DESCRIPTION
Added compatibility for espressifs esp32 and esp8266

Based on the idea from [mostafahk](https://github.com/mostafahk) in [PR#70](https://github.com/arduino-libraries/ArduinoModbus/pull/70/commits) which seems kind of abandoned (last commit 2 years ago)

As the serial configuration enum is defined as int32 on the ESP (instead of int16 or the other platforms), so made the datatype  Dynamic.

This code change will enable the ModbusLibrary to compile sucessfully for ESP32 and ESP8266, but in order to work on those platforms the approriate PR in the RS485 Library will alo have to be merged. 