### PR TITLE
Add RTU compatibility to DUE

### DIFF
--- a/src/libmodbus/modbus-rtu.cpp
+++ b/src/libmodbus/modbus-rtu.cpp
@@ -654,7 +654,11 @@ static int _modbus_rtu_connect(modbus_t *ctx)
         return -1;
     }
 #elif defined(ARDUINO)
+#ifdef ARDUINO_ARCH_SAM
+    ctx_rtu->rs485->begin(ctx_rtu->baud, static_cast<UARTClass::UARTModes>(ctx_rtu->config));
+#else
     ctx_rtu->rs485->begin(ctx_rtu->baud, ctx_rtu->config);
+#endif
     ctx_rtu->rs485->receive();
 #else
     /* The O_NOCTTY flag tells UNIX that this program doesn't want

--- a/src/libmodbus/modbus.c
+++ b/src/libmodbus/modbus.c
@@ -1,6 +1,6 @@
 /*
- * Copyright Â© 2001-2011 StÃ©phane Raimbault <stephane.raimbault@gmail.com>
- * Copyright Â© 2018 Arduino SA. All rights reserved.
+ * Copyright © 2001-2011 Stéphane Raimbault <stephane.raimbault@gmail.com>
+ * Copyright © 2018 Arduino SA. All rights reserved.
  *
  * SPDX-License-Identifier: LGPL-2.1+
  *
@@ -8,19 +8,32 @@
  * http://libmodbus.org/
  */
 
+#ifdef ARDUINO_SAM_DUE
+#include <Arduino.h> //moust be include here to compile
+#endif
+
+
+#ifndef _MSC_VER
+#ifndef ARDUINO_SAM_DUE
+//compile with DUE without those includes
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdarg.h>
-#include <errno.h>
 #include <limits.h>
 #include <time.h>
-#ifndef _MSC_VER
+//make due not compile if included
 #include <unistd.h>
+#endif
+#include <errno.h>
 #endif
 #ifdef ARDUINO
 #include <stdbool.h>
+
+#ifndef ARDUINO_SAM_DUE
 #include <Arduino.h>
+#endif
+
 
 #ifndef DEBUG
 #define printf(...) {}


### PR DESCRIPTION
With use of a modified [ArduinoRs485 lib](https://github.com/NitrofMtl/ArduinoRS485_DUE), make use modbus with Arduino DUE.

Change, add macro:
-In modbus.c: 
  -change order of inclusion
  -remove inclusion that did not prevent compiling ( look like already included in arduino.h)
  -remove the #include <unistd.h>, it did not compile with it, but no problem seen without

-in modbus-rtu.cpp:
  -change the param for Serial.begin from uint16_t to UARTClass::UARTModes